### PR TITLE
libcrypto3 required for TLS connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY src/ src/
 RUN shards build --release --production --static && strip bin/*
 
 FROM scratch
+RUN apk add --no-cache libcrypto3
 USER 2:2
 COPY --from=builder /etc/ssl/cert.pem /etc/ssl/
 COPY --from=builder /tmp/bin/amqpcat /amqpcat


### PR DESCRIPTION
This is to match https://github.com/cloudamqp/amqproxy/commit/430818cf0bf969ab6e083566c698ce343b3a600c
based on that I'm getting the same error `SSL_connect: error:16000069:STORE routines::unregistered scheme` as was mentioned there.